### PR TITLE
sync handshake v2: shared protocol constants for X25519/Ed25519 and encrypted media

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -424,3 +424,105 @@ export interface AesEncryptedMessage {
   /** Base64-encoded 16-byte GCM authentication tag */
   tag: string;
 }
+
+// ********************************************************************************************************************
+// Sync handshake v2 — X25519 key agreement + Ed25519 device identity, bound to a QR pairing secret.
+// Replaces the hybrid-crypto-js RSA handshake. See StagesApp-desktop/ai-docs/SYNC_HANDSHAKE_REDESIGN.md
+// for the protocol, the rationale, and the migration.
+//
+// Every value below is protocol-visible: changing one without changing the other side breaks the
+// handshake, so both apps read them from here rather than declaring their own.
+// ********************************************************************************************************************
+
+/** Bytes of pairing secret carried in the QR code. Regenerated for every sync window. */
+export const PAIRING_SECRET_LENGTH = 32;
+
+/** Field name in the QR payload holding the base64url pairing secret. */
+export const PAIRING_SECRET_FIELD = 'k';
+
+/** Raw byte length of an X25519 or Ed25519 public key. */
+export const CURVE25519_PUBLIC_KEY_LENGTH = 32;
+
+/** Raw byte length of an Ed25519 signature. */
+export const ED25519_SIGNATURE_LENGTH = 64;
+
+/**
+ * HMAC-SHA256 domain-separation labels for the pairing proofs. Distinct per direction so a proof
+ * captured in one direction cannot be replayed in the other.
+ */
+export const DESKTOP_HELLO_LABEL = 'stages-desktop-hello';
+export const MOBILE_HELLO_LABEL = 'stages-mobile-hello';
+
+/** HKDF info prefix. Bump the version suffix on any change to the key schedule. */
+export const SYNC_HKDF_INFO = 'stages-sync-v2';
+
+/** Handshake message field names. */
+export const IDENTITY_PUB_FIELD = 'identityPub';
+export const EPHEMERAL_PUB_FIELD = 'ephemeralPub';
+export const PAIRING_PROOF_FIELD = 'proof';
+export const IDENTITY_SIG_FIELD = 'sig';
+
+/** Desktop's hello, emitted on connect. Replaces the bare public-key string of handshake v1. */
+export interface DesktopHelloMessage {
+  /** Base64 Ed25519 device identity public key — the value stored in TRUSTED_MACHINES. */
+  [IDENTITY_PUB_FIELD]: string;
+  /** Base64 X25519 ephemeral public key, fresh per connection (this is what gives forward secrecy). */
+  [EPHEMERAL_PUB_FIELD]: string;
+  /** Base64 HMAC-SHA256(pairingSecret, DESKTOP_HELLO_LABEL || identityPub || ephemeralPub). */
+  [PAIRING_PROOF_FIELD]: string;
+}
+
+/** Mobile's hello, sent as KEY_CHALLENGE. */
+export interface MobileHelloMessage {
+  /** Base64 Ed25519 device identity public key — the value stored in MOBILE_DEVICES. */
+  [IDENTITY_PUB_FIELD]: string;
+  /** Base64 X25519 ephemeral public key, fresh per connection. */
+  [EPHEMERAL_PUB_FIELD]: string;
+  /**
+   * Base64 HMAC-SHA256(pairingSecret,
+   *   MOBILE_HELLO_LABEL || mobileIdentityPub || mobileEphemeralPub || desktopEphemeralPub).
+   * Desktop verifies this before anything else — it is what proves the caller scanned the QR.
+   */
+  [PAIRING_PROOF_FIELD]: string;
+  /** Base64 Ed25519 signature over the handshake transcript. */
+  [IDENTITY_SIG_FIELD]: string;
+}
+
+/** Desktop's KEY_CHALLENGE response: its signature over the same transcript. */
+export interface DesktopHelloResponse {
+  [IDENTITY_SIG_FIELD]: string;
+}
+
+// ********************************************************************************************************************
+// Encrypted media transport — chunked AES-256-GCM over the HTTP file routes.
+// TLS is not usable here: React Native cannot configure trust for a self-signed cert on a DHCP LAN
+// address, and its WebSocket layer ignores TLS options entirely. See the ADR for the full reasoning.
+// ********************************************************************************************************************
+
+/**
+ * Plaintext bytes per encrypted chunk. Fixed so a plaintext offset maps to a chunk index by
+ * arithmetic, which is what keeps ranged resume working. Chosen to keep the React Native JSI call
+ * count low (~800 calls per 200 MB) rather than for raw throughput.
+ *
+ * Must divide the ranged-download chunk size evenly so range boundaries land on chunk boundaries.
+ */
+export const MEDIA_CHUNK_PLAINTEXT_LENGTH = 256 * 1024;
+
+/** Bytes appended to each chunk: the GCM authentication tag. */
+export const MEDIA_CHUNK_TAG_LENGTH = 16;
+
+/** On-the-wire size of one full chunk. */
+export const MEDIA_CHUNK_WIRE_LENGTH = MEDIA_CHUNK_PLAINTEXT_LENGTH + MEDIA_CHUNK_TAG_LENGTH;
+
+/**
+ * Bytes of random nonce prefix sent once at the head of an encrypted media stream. Each chunk's
+ * 12-byte GCM nonce is `noncePrefix || uint64BE(chunkIndex)`, so nonces are unique per chunk and
+ * never repeat under one session key — the one failure that would catastrophically break GCM.
+ */
+export const MEDIA_NONCE_PREFIX_LENGTH = 4;
+
+/** Header sent by mobile / set by desktop to mark a file body as chunk-encrypted. */
+export const MEDIA_ENCRYPTION_HEADER = 'x-stages-media-encryption';
+
+/** Value of MEDIA_ENCRYPTION_HEADER for the scheme above. */
+export const MEDIA_ENCRYPTION_AES_GCM_CHUNKED = 'aes-256-gcm-chunked-v1';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -515,11 +515,22 @@ export const MEDIA_CHUNK_TAG_LENGTH = 16;
 export const MEDIA_CHUNK_WIRE_LENGTH = MEDIA_CHUNK_PLAINTEXT_LENGTH + MEDIA_CHUNK_TAG_LENGTH;
 
 /**
- * Bytes of random nonce prefix sent once at the head of an encrypted media stream. Each chunk's
- * 12-byte GCM nonce is `noncePrefix || uint64BE(chunkIndex)`, so nonces are unique per chunk and
- * never repeat under one session key — the one failure that would catastrophically break GCM.
+ * Bytes of random per-file nonce, sent once at the head of an encrypted media stream.
+ *
+ * Each file gets its own key:
+ *   fileKey = HKDF-SHA256(sessionKey, salt = fileNonce, info = MEDIA_HKDF_INFO, 32)
+ * and each chunk's 12-byte GCM nonce is uint96BE(chunkIndex), starting at zero.
+ *
+ * Deriving per file is what makes nonce reuse impossible rather than merely unlikely. Sharing one
+ * session key across files and distinguishing them by a short random prefix would only need two
+ * files to collide on that prefix — across a sync carrying thousands of files that is a real
+ * probability, and GCM nonce reuse is catastrophic: it leaks the authentication key, not just one
+ * plaintext. 16 bytes of random salt puts collision odds out of reach.
  */
-export const MEDIA_NONCE_PREFIX_LENGTH = 4;
+export const MEDIA_FILE_NONCE_LENGTH = 16;
+
+/** HKDF info for per-file media key derivation. Bump the suffix if the scheme changes. */
+export const MEDIA_HKDF_INFO = 'stages-media-v1';
 
 /** Header sent by mobile / set by desktop to mark a file body as chunk-encrypted. */
 export const MEDIA_ENCRYPTION_HEADER = 'x-stages-media-encryption';


### PR DESCRIPTION
Constants only — no behavior change. This unblocks the sync handshake replacement in StagesApp-desktop and StagesApp-mobile, which both need these values to agree.

Full design: `ai-docs/SYNC_HANDSHAKE_REDESIGN.md` in the desktop repo.

## Why

A review of the sync encryption found three things:

1. **The QR code carries no secret**, so pairing authenticates nobody. Desktop verifies the mobile signature using the public key supplied *in the same message* — which proves only that the sender owns some keypair — then writes it into `MOBILE_DEVICES` with no confirmation. Any device reaching the port during a sync window can complete the handshake. In the other direction, Mobile's trust-on-first-use prompt shows the hostname *from the scanned QR*, so an impersonator's prompt reads correctly.
2. **No forward secrecy.** The AES session key is RSA-transported under Desktop's static key, which sits unencrypted in `stages-settings.sqlite3`. Captured traffic is decryptable later by anyone who obtains that file.
3. **Dated primitives on an unmaintained library.** `hybrid-crypto-js` (last published ~2020) does AES-CBC and RSA-OAEP-SHA1, and its `verify()` takes the digest algorithm from the attacker-supplied signature blob. Mobile's identity key is **1024-bit**, below NIST's floor since 2013.

It is also slow: **~4.5s of blocking crypto per sync**, measured on production builds (3.59s Mobile on Hermes, which has no JIT in any build; 0.92s Desktop). X25519 + HKDF measured 1.2ms.

## What the constants cover

**Handshake** — per-window QR pairing secret, X25519 ephemeral agreement, Ed25519 device identity, HKDF labels, and the hello message shapes. Both sides prove possession of the pairing secret via HMAC, which closes the pairing hole in both directions. Domain-separation labels differ per direction so a proof cannot be replayed the other way.

**Encrypted media** — media files currently cross the network as plaintext HTTP, which is a passive exposure (an observer does not need to race the sync window). TLS is not usable: iOS/macOS do not support TLS 1.3 external PSK, and RN's WebSocket layer ignores TLS options entirely while its pinning ecosystem assumes a known domain rather than a DHCP LAN address. So: chunked AES-256-GCM under the session key both sides already hold. Fixed 256 KiB chunks keep ranged resume working (plaintext offset → chunk index is arithmetic), and nonces are counter-derived so they never repeat under one key.

Measured ~790 MB/s against ~25 MB/s Wi-Fi, so streamed it adds no wall clock. Size overhead 0.006%.

## Merge order

Merge this first, then the two app PRs repin to the resulting master commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)